### PR TITLE
Fix text card styling

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -1,6 +1,6 @@
 
 body {
-    font-family: Georgia, "Times New Roman", serif;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
     position: relative;
     height: 100vh;
     margin: 0;
@@ -9,11 +9,14 @@ body {
 
 .card {
     position: absolute;
-    top: 50%;
+    top: 20vh;
     left: 50%;
-    transform: translate(-50%, -50%);
+    transform: translateX(-50%);
     max-width: 500px;
     text-align: center;
+    border: none;
+    background: none;
+    padding: 0;
 }
 
 .card h1 {


### PR DESCRIPTION
## Summary
- refine typography with a cross‑platform system font stack
- anchor card to a fixed vertical offset so it doesn't move between refreshes
- remove any default border, background, or padding around the card

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68578ad54ca0832980f3e3afc3b5e1be