### PR TITLE
Fix shuffle button placement

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -9,7 +9,6 @@
 </head>
 <body>
     <div id="card" class="card"></div>
-    <button id="shuffleButton" class="shuffle-btn" aria-label="Shuffle">🔀</button>
     <script src="marketCards.js"></script>
     <script src="script.js"></script>
 </body>

--- a/docs/script.js
+++ b/docs/script.js
@@ -7,13 +7,12 @@ function showRandomCard() {
         <p><strong>Why Infinite?</strong> ${card["Why Infinite?"]}</p>
         <p><strong>Examples:</strong> ${card["Examples"]}</p>
         <p><strong>Notables:</strong> ${card["Notables"]}</p>
+        <button id="shuffleButton" class="shuffle-btn" aria-label="Shuffle">🔀</button>
     `;
-}
-
-document.addEventListener('DOMContentLoaded', () => {
-    showRandomCard();
     const btn = document.getElementById('shuffleButton');
     if (btn) {
         btn.addEventListener('click', showRandomCard);
     }
-});
+}
+
+document.addEventListener('DOMContentLoaded', showRandomCard);


### PR DESCRIPTION
## Summary
- remove standalone shuffle button markup
- render the shuffle button inside the card so it appears beneath the text

## Testing
- `node -c docs/script.js`


------
https://chatgpt.com/codex/tasks/task_e_685811e9584483299e05857e183dffbd