### PR TITLE
Fix card height and shuffle button position

### DIFF
--- a/docs/script.js
+++ b/docs/script.js
@@ -3,10 +3,12 @@ function showRandomCard() {
     const card = marketCards[Math.floor(Math.random() * marketCards.length)];
     const container = document.getElementById('card');
     container.innerHTML = `
-        <h1>${card["Market"]}</h1>
-        <p><strong>Why Infinite?</strong> ${card["Why Infinite?"]}</p>
-        <p><strong>Examples:</strong> ${card["Examples"]}</p>
-        <p><strong>Notables:</strong> ${card["Notables"]}</p>
+        <div class="card-body">
+            <h1>${card["Market"]}</h1>
+            <p><strong>Why Infinite?</strong> ${card["Why Infinite?"]}</p>
+            <p><strong>Examples:</strong> ${card["Examples"]}</p>
+            <p><strong>Notables:</strong> ${card["Notables"]}</p>
+        </div>
         <button id="shuffleButton" class="shuffle-btn" aria-label="Shuffle">🔀</button>
     `;
     const btn = document.getElementById('shuffleButton');

--- a/docs/style.css
+++ b/docs/style.css
@@ -17,6 +17,16 @@ body {
     border: none;
     background: none;
     padding: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.card-body {
+    min-height: 220px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
 }
 
 .card h1 {


### PR DESCRIPTION
## Summary
- keep card button anchored by wrapping card text in `.card-body`
- add min height so button doesn't jump around

## Testing
- `npm test` *(fails: Could not read package.json)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685812aaab5883299e3bf8ee9b85a510