### PR TITLE
Replace emoji icons with outlined SVG icons

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -9,7 +9,9 @@
 </head>
 <body>
     <div id="card" class="card"></div>
-    <button id="shareButton" class="share-btn" aria-label="Share">📤</button>
+    <button id="shareButton" class="share-btn" aria-label="Share">
+        <img src="share.svg" alt="Share" width="32" height="32" />
+    </button>
     <script src="marketCards.js"></script>
     <script src="script.js"></script>
 </body>

--- a/docs/script.js
+++ b/docs/script.js
@@ -9,7 +9,9 @@ function showRandomCard() {
             <p><strong>Examples:</strong> ${card["Examples"]}</p>
             <p><strong>Notables:</strong> ${card["Notables"]}</p>
         </div>
-        <button id="shuffleButton" class="shuffle-btn" aria-label="Shuffle">🔀</button>
+        <button id="shuffleButton" class="shuffle-btn" aria-label="Shuffle">
+            <img src="shuffle.svg" alt="Shuffle" width="32" height="32" />
+        </button>
     `;
     const btn = document.getElementById('shuffleButton');
     if (btn) {

--- a/docs/share.svg
+++ b/docs/share.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4 18v2h16v-2"/>
+  <path d="M12 3v13"/>
+  <path d="M8 7l4-4 4 4"/>
+</svg>

--- a/docs/shuffle.svg
+++ b/docs/shuffle.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 4h4l5 8"/>
+  <path d="M3 20h4l5-8"/>
+  <path d="M17 4l4 4-4 4"/>
+  <path d="M17 20l4-4-4-4"/>
+</svg>

--- a/docs/style.css
+++ b/docs/style.css
@@ -41,18 +41,24 @@ body {
 .shuffle-btn {
     display: block;
     margin: 20px auto 0;
-    font-size: 32px;
     background: none;
     border: none;
     cursor: pointer;
+}
+.shuffle-btn img {
+    width: 32px;
+    height: 32px;
 }
 
 .share-btn {
     position: fixed;
     bottom: 20px;
     right: 20px;
-    font-size: 32px;
     background: none;
     border: none;
     cursor: pointer;
+}
+.share-btn img {
+    width: 32px;
+    height: 32px;
 }


### PR DESCRIPTION
## Summary
- swap share and shuffle emoji buttons for custom SVG icons
- update button CSS for images
- add new `share.svg` and `shuffle.svg` icons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685818d24d1483298b909c923b67d3d7